### PR TITLE
Update README.md to account for the character change in package name for Meteor 0.9.2 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Current Version: 0.7.3
 
 step 4 
 ```coffeescript
-L.Icon.Default.imagePath = 'packages/mrt:leaflet/images'
+L.Icon.Default.imagePath = 'packages/mrt_leaflet/images'
 ```
 
 step 5 - example


### PR DESCRIPTION
Added _ character and removed the : character, so mrt_leaflet will work with any Meteor version after 0.9.2
