### PR TITLE
remove deprecated VML behaviour url

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@ Package.describe({
   summary: "leaflet - mobile-friendly maps.",
   git: "https://github.com/bevanhunt/meteor-leaflet.git",
   author: "Bevan Hunt <bevan@bevanhunt.com> (http://bevanhunt.com)",
-  version: "2.0.0",
+  version: "2.0.1",
   license: "MIT"
 });
 

--- a/styles/leaflet.css
+++ b/styles/leaflet.css
@@ -74,7 +74,8 @@
   height: 1px;
 }
 .lvml {
-  behavior: url(#default#VML);
+  /* removed this line to avoid breaking css build scripts trying to resolve path */
+  /* behavior: url(#default#VML);*/
   display: inline-block;
   position: absolute;
 }


### PR DESCRIPTION
VML was IE specific is not supported anumore since IE9.

This behaviour url, make the css-minifier trying to resolve to a non-existing file, breaking the css minification process.

Since VML is not supported anymore, I would suggest to remove this behavior.

We could also file a pull request to the css minifier package, validating strings inside url() as proper file refs before trying to resolve.

Lots of people and asset minifiers are struggling with this:
https://forums.meteor.com/t/arguments-to-path-resolve-must-be-strings-minifying-app-stylesheet/26213
https://github.com/meteor/meteor/issues/7394
https://github.com/conveyal/otp.js/issues/4
https://github.com/kriswallsmith/assetic/issues/591